### PR TITLE
feat: add /implement command to contradiction-tools plugin

### DIFF
--- a/.claude-plugins/contradiction-tools/README.md
+++ b/.claude-plugins/contradiction-tools/README.md
@@ -6,35 +6,11 @@ GitHub Issue を単一の真実の情報源として、進捗ドキュメント�
 
 ### 前提条件
 
-1. **issync CLI**のインストール（進捗ドキュメントの同期に使用）:
-
-   ```bash
-   npm install -g @mh4gf/issync
-   ```
-
-2. **GitHub CLI (`gh`)**のインストール（GitHub 操作に使用）:
-
-   - インストール方法: https://cli.github.com/
-
-3. **GITHUB_TOKEN 環境変数**の設定:
-
-   - ローカル開発: `export GITHUB_TOKEN=$(gh auth token)`
-   - GitHub Actions: ワークフローで自動設定済み（設定不要）
-
-4. **issync watch**の起動（推奨）:
-   ```bash
-   issync watch
-   ```
-
-5. **GitHub Projects統合の設定**（オプション）:
-
-   GitHub Projectsを使用するプロジェクトでは、環境変数を設定してください：
-
-   ```bash
-   export CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS=true
-   ```
-
-   未設定の場合、GitHub Projects操作（Status/Stage変更）はスキップされます。
+1. **issync CLI**: `npm install -g @mh4gf/issync`
+2. **GitHub CLI (`gh`)**: https://cli.github.com/
+3. **GITHUB_TOKEN**: `export GITHUB_TOKEN=$(gh auth token)` (GitHub Actionsでは自動設定)
+4. **issync watch**: `issync watch` (推奨)
+5. **GitHub Projects統合** (オプション): `export CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS=true`
 
 ### インストール
 
@@ -100,397 +76,132 @@ retrospective
 
 ### `/contradiction-tools:plan` - 進捗ドキュメント初期作成
 
-**何ができる:**
-GitHub Issue からコードベース調査を含む全てのコンテキストを自動収集し、精度の高い進捗ドキュメントを生成します。`issync init`の実行から、コードベース調査、基本セクションの記入、Open Questions の精査、GitHub Projects Status の自動変更（plan → poc）まで、全てを一括実行します。
+**何ができる:** GitHub Issueからコードベース調査を含む全コンテキストを自動収集し、進捗ドキュメントを生成。`issync init`、コードベース調査、基本セクション記入、Open Questions精査、GitHub Projects Status変更（plan → poc）を一括実行。
 
-**ユーザーがやること:**
-issue 上に同期された進捗ドキュメントの Open Questions を見て判断するだけ。コードベース調査や進捗ドキュメント作成は全て自動化されます。
+**いつ使う:** GitHub Issue作成後すぐ
 
-**いつ使う:**
+**使い方:** `/contradiction-tools:plan https://github.com/owner/repo/issues/123`
 
-- GitHub Issue 作成後すぐ
+**自動実行内容:** ファイル名決定 & issync init → Issue内容確認 → コードベース調査 → 基本セクション記入 → Open Questions精査 → issync push → Status変更（plan → poc）
 
-**使い方:**
+**完了後:** Open Questionsを確認・判断 → POC実装開始
 
-1. 前提条件を確認:
-
-   - GitHub Issue が作成されている
-   - `issync watch` が起動している（推奨）
-
-2. コマンドを実行:
-
-   ```bash
-   /contradiction-tools:plan https://github.com/owner/repo/issues/123
-   ```
-
-3. plugin が以下を自動実行:
-
-   - **ステップ 1**: ファイル名決定 & `issync init` 実行
-   - **ステップ 2**: GitHub Issue 内容の確認
-   - **ステップ 3**: コードベース調査（類似機能、技術スタック、テストコード、関連ファイル、ドキュメント）
-   - **ステップ 4**: 進捗ドキュメント基本セクション記入（Purpose/Overview、Context & Direction、Acceptance Criteria）
-   - **ステップ 5**: Open Questions 精査（コードで確認可能な情報を除外し、5-10 項目に絞り込み）
-   - **ステップ 6**: issync push で同期
-   - **ステップ 7**: GitHub Projects Status を自動変更（plan → poc）
-
-4. 完了後にやること:
-   - Open Questions を確認し、判断が必要な項目について決定
-   - POC 実装を開始
+詳細は`commands/plan.md`を参照。
 
 ---
 
 ### `/contradiction-tools:review-poc` - POC レビュー
 
-**何ができる:**
-POC 完了後、POC で得た知見を分析し、人間の意思決定のための材料を整理します。POC PR 情報取得、Acceptance Criteria 検証、Discoveries & Insights 追記、Open Questions 強化、Decision Log 推奨案記入、POC PR クローズ、issync push による同期を一括実行します。
+**何ができる:** POC完了後、得た知見を分析し、人間の意思決定のための材料を整理。POC PR情報取得、Acceptance Criteria検証、Discoveries & Insights追記、Open Questions強化、Decision Log推奨案記入、POC PRクローズ、issync push同期を一括実行。
 
-**いつ使う:**
+**いつ使う:** POC完了後（技術検証完了時）、アーキテクチャ決定前（意思決定材料が必要な時）、本実装前
 
-- POC 完了後（技術検証が完了し、実装の知見が得られた時）
-- アーキテクチャ決定前（人間が意思決定するための材料が必要な時）
-- 本実装前（implement に進む前に、POC の結果を整理する時）
+**使い方:** `/contradiction-tools:review-poc https://github.com/owner/repo/pull/123`
 
-**使い方:**
+**自動実行内容:** POC PR情報取得 → Discoveries & Insights参照 → Acceptance Criteria検証 → Discoveries & Insights追記 → Open Questions追加 → Decision Log推奨案記入 → Specification記入（オプション） → POC PRクローズ → issync push
 
-1. 前提条件を確認:
+**完了後（人間が実施）:** POC検証結果確認 → Open Questions検討・意思決定 → Decision Log推奨案の承認/修正/却下 → 承認後、手動でStatusを`implement`に変更
 
-   - 現在の GitHub Issue Status が `architecture-decision` である
-   - POC 実装が完了し、PR が作成されている
-   - `GITHUB_TOKEN` 環境変数が設定されている
-
-2. コマンドを実行:
-
-   ```bash
-   /contradiction-tools:review-poc https://github.com/owner/repo/pull/123
-   ```
-
-3. plugin が以下を自動実行:
-
-   - **ステップ 1**: POC PR 情報取得（description, commits, diff, comments）
-   - **ステップ 2**: Discoveries & Insights 参照
-   - **ステップ 3**: Acceptance Criteria 検証（達成/未達成を明確化、未達成の理由分析）
-   - **ステップ 4**: Discoveries & Insights 追記（POC で発見した技術的事実）
-   - **ステップ 5**: Open Questions 追加（未達成項目の論点化、選択肢の明確化）
-   - **ステップ 6**: Decision Log 推奨案記入（人間の最終決定を前提とした推奨案）
-   - **ステップ 7**: Specification / 仕様記入（POC で確認された部分のみ、オプショナル）
-   - **ステップ 8**: POC PR クローズ
-   - **ステップ 9**: issync push で同期
-
-4. 完了後、**人間が進捗ドキュメントをレビュー**:
-   - POC 検証結果の確認
-   - Open Questions の検討・意思決定
-   - Decision Log 推奨案の承認/修正/却下
-   - 承認後、手動で Status を `implement` に変更
+詳細は`commands/review-poc.md`を参照。
 
 ---
 
 ### `/contradiction-tools:compact-plan` - 進捗ドキュメント圧縮
 
-**何ができる:**
-進捗ドキュメントが大きくなりすぎた際に、情報量を保持したまま文量を削減します。重複情報の削減、解決済み Open Questions の整理、完了済み Phase の簡潔化、矛盾検出と報告を一括実行します。
+**何ができる:** 進捗ドキュメントが大きくなりすぎた際に、情報量を保持したまま文量を削減。重複情報削減、解決済みOpen Questions整理、完了Phase簡潔化、矛盾検出と報告を一括実行。
 
-**いつ使う:**
+**いつ使う:** 500行以上に膨らんだ時、Phase完了時、Open Questions大量解決時、retrospective前、矛盾の疑いがある時
 
-- 進捗ドキュメントが 500 行以上に膨らんだ時（読みづらくなる前に定期的に圧縮）
-- Phase が完了した時（完了フェーズの詳細を簡潔化）
-- Open Questions が大量に解決された時（解決済み質問を整理）
-- retrospective 前（振り返りを書く前にドキュメントを整理）
-- 矛盾の疑いがある時（矛盾検出機能で一貫性をチェック）
+**使い方:** `/contradiction-tools:compact-plan .issync/docs/plan-123-example.md`
 
-**使い方:**
+**自動実行内容:** 進捗ドキュメント分析 → 圧縮処理適用 → 矛盾検出とレポート → watchモードで自動同期
 
-1. コマンドを実行（ファイルパスを指定）:
-
-   ```bash
-   /contradiction-tools:compact-plan .issync/docs/plan-123-example.md
-   ```
-
-2. plugin が以下を自動実行:
-
-   - 進捗ドキュメントの分析（総行数、セクション別行数、重複、矛盾）
-   - progress-document-template.md との比較
-   - 圧縮処理の適用
-   - 矛盾検出とレポート
-   - watch モードが起動している場合は自動的に GitHub Issue に同期
-
-3. 圧縮結果レポートを確認:
-   - 削減された行数と削減率
-   - 適用された圧縮処理の詳細
-   - 検出された矛盾（ある場合）
+詳細は`commands/compact-plan.md`を参照。
 
 ---
 
 ### `/contradiction-tools:implement` - 実装フェーズ自動化
 
-**何ができる:**
-進捗ドキュメントの内容を理解した上で実装を進め、作業中は常に進捗ドキュメントを更新し続けます。`/understand-progress`による進捗ドキュメント読み込み、Specification/仕様に基づいた実装、テスト実行、進捗ドキュメントの継続的更新、issync pushによる同期を一括実行します。
+**何ができる:** 進捗ドキュメント内容を理解した上で実装を進め、作業中は常に進捗ドキュメントを更新。`/understand-progress`による読み込み、Specification/仕様に基づいた実装、テスト実行、継続的更新、issync push同期を一括実行。
 
-**いつ使う:**
+**いつ使う:** implementステート（アーキテクチャ決定後、本実装フェーズ）、GitHub Actions（Claude Code Action）から`@claude`コメントで実装依頼する時
 
-- implement ステート（アーキテクチャ決定後、本実装フェーズ）
-- GitHub Actions（Claude Code Action）から`@claude`コメントで実装を依頼する時
-- 進捗ドキュメントに基づいた実装を自動化したい時
+**使い方:** `/contradiction-tools:implement` | `/contradiction-tools:implement https://github.com/owner/repo/issues/123` | `/contradiction-tools:implement 123`
 
-**使い方:**
+**自動実行内容:** `/understand-progress`で読み込み → Specification確認 → 実装開始 → 進捗ドキュメント継続的更新 → テスト実行 → issync push → Git commit & PR作成
 
-1. 前提条件を確認:
+**完了後:** PRレビュー依頼、Open Questions解消、サブissueの場合は`/complete-sub-issue`で親issueに反映
 
-   - 進捗ドキュメントが作成されている（`/contradiction-tools:plan`実行済み）
-   - アーキテクチャ決定が完了している（`Specification / 仕様`セクションが記入済み）
-   - `issync watch`が起動している（推奨）
+**重要ポイント:** 進捗ドキュメント駆動、継続的更新（Single Source of Truth維持）、テスト駆動、GitHub Actions連携
 
-2. コマンドを実行:
-
-   ```bash
-   /contradiction-tools:implement                                          # state.ymlから選択
-   /contradiction-tools:implement https://github.com/owner/repo/issues/123 # Issue URL指定
-   /contradiction-tools:implement 123                                       # Issue番号指定
-   ```
-
-3. plugin が以下を自動実行:
-
-   - **ステップ 1**: `/understand-progress`で進捗ドキュメントを読み込み
-   - **ステップ 2**: 進捗ドキュメントの`Specification / 仕様`セクションを確認
-   - **ステップ 3**: 仕様に基づいて実装を開始
-   - **ステップ 4**: 実装中は進捗ドキュメントを継続的に更新（Decision Log、Discoveries & Insights、Open Questions等）
-   - **ステップ 5**: テストを実行（単体テスト、型チェック、コード品質チェック）
-   - **ステップ 6**: `issync push`で進捗ドキュメントをGitHub Issueに同期
-   - **ステップ 7**: Git commitとPR作成
-
-4. 完了後にやること:
-   - PRのレビュー依頼
-   - 必要に応じてOpen Questionsの解消
-   - サブissueの場合は`/complete-sub-issue`で親issueに反映
-
-**重要ポイント:**
-
-- **進捗ドキュメント駆動**: `Specification / 仕様`セクションに基づいて実装
-- **継続的更新**: 実装中の意思決定や発見を常に進捗ドキュメントに記録（Single Source of Truth維持）
-- **テスト駆動**: `Validation & Acceptance Criteria`に基づいてテストを追加・実行
-- **GitHub Actions連携**: `@claude /contradiction-tools:implement`コメントで実行可能
+詳細は`commands/implement.md`を参照。
 
 ---
 
 ### `/contradiction-tools:understand-progress` - 進捗ドキュメント読み込み
 
-**何ができる:**
-セッション開始時に、state.yml から同期中の進捗ドキュメントを選択して読み込みます。複数の進捗ドキュメントがある場合は選択肢を提示し、1つの場合は自動選択します。読み込み後、Issue URL、最終同期時刻、重要なセクション情報を表示します。
+**何ができる:** セッション開始時に、state.ymlから同期中の進捗ドキュメントを選択して読み込み。複数の場合は選択肢提示、1つの場合は自動選択。Issue URL、最終同期時刻、重要なセクション情報を表示。
 
-**いつ使う:**
+**いつ使う:** セッション開始時、複数タスク同時進行時、進捗ドキュメント状態確認時
 
-- セッション開始時（進捗ドキュメントのコンテキストを把握したい時）
-- 複数のタスクを同時進行している時（どの進捗ドキュメントで作業するか選択したい時）
-- 進捗ドキュメントの現在の状態を確認したい時
+**使い方:** `/contradiction-tools:understand-progress` | `/contradiction-tools:understand-progress <file_path>`
 
-**使い方:**
+**自動実行内容:** `issync list`で一覧取得 → 選択（複数の場合）→ Readツールで読み込み → 情報表示（Issue URL、最終同期時刻、Purpose/Overview要約、Open Questions件数、推測Status）
 
-1. コマンドを実行:
-
-   ```bash
-   /contradiction-tools:understand-progress                    # state.ymlから選択
-   /contradiction-tools:understand-progress <file_path>        # 明示的パス指定
-   ```
-
-2. plugin が以下を自動実行:
-
-   - **引数なしの場合**: `issync list` で同期中のファイル一覧を取得
-   - **複数ファイル**: 選択肢を提示（番号入力）
-   - **1つのみ**: 確認後に自動選択
-   - **引数ありの場合**: 指定パスを直接読み込み
-
-3. Read ツールでファイルを読み込み、以下の情報を表示:
-   - Issue URL と最終同期時刻
-   - Purpose/Overview の要約
-   - Open Questions の件数
-   - 推測される Status（plan/poc/architecture-decision/implement 等）
-
-4. 完了後にやること:
-   - 進捗ドキュメントの内容を確認
-   - Open Questions を確認し、必要に応じて解消
-   - 次のステップ（POC/実装等）を開始
+詳細は`commands/understand-progress.md`を参照。
 
 ---
 
 ### `/contradiction-tools:create-sub-issue` - タスクのサブ issue 化
 
-**何ができる:**
-新規タスクを GitHub Issue として作成し、親 issue とのリンクを自動管理します。タスク概要入力、親 issue 情報取得、LLM によるタイトル・本文生成、GitHub Issue 作成、Sub-issues API による紐づけを一括実行します。
+**何ができる:** 新規タスクをGitHub Issueとして作成し、親issueとのリンクを自動管理。タスク概要入力、親issue情報取得、LLMによるタイトル・本文生成、GitHub Issue作成、Sub-issues APIによる紐づけを一括実行。
 
-**いつ使う:**
+**いつ使う:** plan（初期タスク整理時）、architecture-decision（アーキテクチャ決定後、実装タスクをサブissue化したい時）、implement（実装中に新たなタスク判明時）
 
-- plan: 初期タスクを整理し、サブ issue を作成する時
-- architecture-decision: アーキテクチャ決定後、実装タスクをサブ issue 化したい時
-- implement: 実装中に新たなタスクが判明した時
+**使い方:** `/contradiction-tools:create-sub-issue` (インタラクティブモード) | `/contradiction-tools:create-sub-issue "タスク1" "タスク2"` (引数モード)
 
-**使い方:**
+**設計原則:** インタラクティブモード（デフォルトで1つ作成、階層的分解）、引数モード（複数の独立タスクが明確な場合）、推奨ワークフロー（1つ作成 → `/plan`で詳細化 → 必要に応じて孫issue作成）
 
-1. コマンドを実行:
-
-   ```bash
-   /contradiction-tools:create-sub-issue                          # インタラクティブモード（1つのタスク概要を入力）
-   /contradiction-tools:create-sub-issue "自動アクション設計" "CI/CD統合"  # 引数モード（複数可）
-   ```
-
-2. **インタラクティブモード**の場合:
-
-   - プロンプト: 「1 つのサブ issue を作成します。タスク概要を入力してください」
-   - タスク概要を 1 つ入力（例: "Status 変更時の自動アクション設計"）
-   - LLM が親 issue のコンテキストから適切なタイトルと本文を生成
-   - ユーザー確認後、GitHub Issue を作成
-   - Sub-issues API で親 issue と紐づけ
-
-3. **引数モード**の場合:
-
-   - 引数で指定された複数のタスク概要から一括作成
-   - 各タスクに対して LLM がタイトルと本文を生成
-   - Sub-issues 順序設定で作成順序を維持
-
-4. 作成されたサブ issue を確認:
-   - 各サブ issue の Status を適切に設定（plan 等）
-   - 必要に応じて各サブ issue で `/contradiction-tools:plan` コマンドを実行
-
-**設計原則:**
-
-- **インタラクティブモード**: デフォルトで 1 つのサブ issue を作成（階層的分解）
-- **引数モード**: 複数の独立したタスクが明確な場合に一括作成
-- **推奨ワークフロー**: まず 1 つ作成 → `/contradiction-tools:plan`で詳細化 → 必要に応じて孫 issue を作成
+詳細は`commands/create-sub-issue.md`を参照。
 
 ---
 
 ### `/contradiction-tools:complete-sub-issue` - サブ issue 完了
 
-**何ができる:**
-サブ issue 完了時に親 issue の進捗ドキュメントを自動更新し、完了サマリーと Follow-up 事項を親 issue に反映します。サブ issue 情報のフェッチ、完了情報の抽出、親 issue 更新、サブ issue クローズ、完了通知を一括実行します。
+**何ができる:** サブissue完了時に親issueの進捗ドキュメントを自動更新し、完了サマリーとFollow-up事項を親issueに反映。サブissue情報フェッチ、完了情報抽出、親issue更新、サブissueクローズ、完了通知を一括実行。
 
-**いつ使う:**
+**いつ使う:** retrospective（サブissueの振り返り記入後）、サブissueのclose時
 
-- retrospective: サブ issue の振り返り記入後、親 issue に完了情報を反映する時
-- サブ issue の close 時: 完了サマリーと Follow-up 事項を親 issue に自動転記したい時
+**使い方:** `/contradiction-tools:complete-sub-issue https://github.com/owner/repo/issues/124`
 
-**使い方:**
+**自動実行内容:** サブissue情報フェッチ → 完了情報抽出 → 親issue更新（Tasksセクション完了マーク、Outcomes & Retrospectives追加、Follow-up Issues振り分け）→ サブissueクローズ → 完了通知
 
-1. 前提条件を確認:
+**Follow-up Issues振り分け:** 実装タスク → Tasksセクション、未解決の質問・改善課題 → Open Questionsセクション、別issue扱い申し送り事項 → Follow-up Issuesセクション
 
-   - サブ issue の進捗ドキュメントに Outcomes & Retrospectives と Follow-up Issues が記入されている
-   - 親 issue の進捗ドキュメントがローカルに存在
-   - `issync watch`が実行中（推奨）
-
-2. コマンドを実行:
-
-   ```bash
-   /contradiction-tools:complete-sub-issue https://github.com/owner/repo/issues/124
-   ```
-
-3. plugin が以下を自動実行:
-   - サブ issue 情報のフェッチと親 issue 番号の抽出
-   - サブ issue の進捗ドキュメントから完了情報を抽出（Outcomes & Retrospectives、Follow-up Issues）
-   - 親 issue の進捗ドキュメントを更新
-     - Tasks セクション: 該当タスクを完了マーク
-     - Outcomes & Retrospectives: サブタスク完了サマリー追加
-     - Follow-up Issues の振り分け（Tasks、Open Questions、Follow-up Issues に適切に配置）
-   - サブ issue の close
-   - 完了通知（watch モードで自動同期）
-
-**Follow-up Issues 振り分けロジック:**
-
-- 「実装タスク」→ 親 issue の**Tasks セクション**に`(未Issue化)`として追加
-- 「未解決の質問・改善課題」→ 親 issue の**Open Questions セクション**に追加
-- 「別 issue として扱うべき申し送り事項」→ 親 issue の**Follow-up Issues セクション**に追加
-
-**運用フロー:**
-
-1. サブ issue で開発完了（plan → retrospective）
-2. サブ issue の進捗ドキュメントに Outcomes & Retrospectives と Follow-up Issues を記入
-3. `/complete-sub-issue <サブissue URL>`を実行
-4. 親 issue の Tasks セクションが自動で完了マーク
-5. 親 issue の Outcomes & Retrospectives にサブタスク完了サマリーが自動追加
-6. サブ issue の Follow-up Issues が親 issue の適切なセクションに自動振り分け
-7. サブ issue が自動で close
+詳細は`commands/complete-sub-issue.md`を参照。
 
 ## Appendix
 
 ### 詳細なインストール方法
 
-#### issync リポジトリを clone した場合（開発者向け）
+**issyncリポジトリをcloneした場合（開発者向け）:**
+1. `/plugin marketplace add <リポジトリのパス>/.claude-plugins`
+2. `/plugin install contradiction-tools@issync-plugins`
+3. `/plugin list`で確認
 
-1. ローカルパスでマーケットプレイスを追加:
-
-   ```bash
-   # Claude Codeで実行（絶対パスを使用）:
-   /plugin marketplace add <リポジトリのパス>/.claude-plugins
-   # 例: /plugin marketplace add /Users/mh4gf/ghq/github.com/MH4GF/issync/.claude-plugins
-   ```
-
-2. plugin をインストール:
-
-   ```bash
-   /plugin install contradiction-tools@issync-plugins
-   ```
-
-3. インストール確認:
-   ```bash
-   /plugin list
-   ```
-
-#### Plugin 更新方法
-
-plugin が更新された場合、以下の手順で最新版に更新できます：
-
+**Plugin更新方法:**
 ```bash
-# 1. マーケットプレイスを更新（GitHubから最新情報を取得）
 /plugin marketplace update issync-plugins
-
-# 2. pluginを再インストール
 /plugin install contradiction-tools@issync-plugins
 ```
 
 ### トラブルシューティング
 
-**Q: plugin が見つからないと言われる**
+**Q: pluginが見つからない** → マーケットプレイス名を確認: `contradiction-tools@issync-plugins`
 
-A: マーケットプレイス名を確認してください。正しい形式は `contradiction-tools@issync-plugins` です（`@issync-plugins` はマーケットプレイス名）。
+**Q: 古いバージョンのまま** → `/plugin marketplace update issync-plugins` → `/plugin uninstall contradiction-tools@issync-plugins` → `/plugin install contradiction-tools@issync-plugins`
 
-**Q: 古いバージョンのまま更新されない**
-
-A: 以下を試してください：
-
-```bash
-# 1. マーケットプレイスを更新
-/plugin marketplace update issync-plugins
-
-# 2. pluginをアンインストール
-/plugin uninstall contradiction-tools@issync-plugins
-
-# 3. 再インストール
-/plugin install contradiction-tools@issync-plugins
-```
-
-**Q: ローカル開発版を使いたい（plugin 開発者向け）**
-
-A: issync リポジトリを clone し、ローカルパスからマーケットプレイスを追加してください：
-
-```bash
-# issyncリポジトリをclone
-git clone https://github.com/MH4GF/issync.git
-# または: ghq get MH4GF/issync
-
-# ローカルパスでマーケットプレイスを追加（絶対パスを使用）
-/plugin marketplace add /path/to/issync
-
-# 例（ghqを使っている場合）:
-# /plugin marketplace add /Users/username/ghq/github.com/MH4GF/issync
-
-# インストール
-/plugin install contradiction-tools@issync-plugins
-```
-
-ローカル開発版を使用している場合、変更を反映するには：
-
-```bash
-# pluginを再インストール
-/plugin uninstall contradiction-tools@issync-plugins
-/plugin install contradiction-tools@issync-plugins
-```
+**Q: ローカル開発版を使いたい** → issyncリポジトリをclone → `/plugin marketplace add /path/to/issync` → `/plugin install contradiction-tools@issync-plugins`。変更を反映するには再インストール。
 
 ### Plugin の構造
 

--- a/.claude-plugins/contradiction-tools/commands/implement.md
+++ b/.claude-plugins/contradiction-tools/commands/implement.md
@@ -9,16 +9,10 @@ description: 進捗ドキュメントに基づいた実装を進め、作業中�
 ## 使用方法
 
 ```bash
-/implement                                          # 引数なし: state.ymlから選択
+/implement                                          # state.ymlから選択
 /implement https://github.com/owner/repo/issues/123 # Issue URL指定
 /implement 123                                       # Issue番号指定
 ```
-
-**引数**:
-- `issue_url_or_number` (オプション): GitHub Issue URLまたはIssue番号
-  - 省略時: state.ymlから同期中のファイルを選択
-  - Issue URL指定: `/implement https://github.com/owner/repo/issues/123`
-  - Issue番号指定: `/implement 123`
 
 ## コンテキスト
 
@@ -30,8 +24,7 @@ description: 進捗ドキュメントに基づいた実装を進め、作業中�
 
 ## 前提条件
 
-- `GITHUB_TOKEN`環境変数が設定されている
-- `issync watch`が起動している（推奨）
+プロジェクト全体の前提条件は`README.md`を参照。このコマンド固有の前提条件:
 - 進捗ドキュメントが既に作成されている（`/contradiction-tools:plan`実行済み）
 - アーキテクチャ決定が完了している（`Specification / 仕様`セクションが記入済み）
 
@@ -70,48 +63,21 @@ description: 進捗ドキュメントに基づいた実装を進め、作業中�
 
 ### ステップ4: 進捗ドキュメントの継続的更新（**最重要**）
 
-実装を進める中で、**必ず進捗ドキュメントを継続的に更新してください**。これは最も重要なステップです。
+実装を進める中で、**必ず進捗ドキュメントを継続的に更新してください**。
 
 **更新タイミング:**
-- **主要な決定時**: 実装方針やアーキテクチャ決定が変更された場合は、`Decision Log`セクションを更新
-- **実装進捗時**: 機能実装が完了した際は、`Discoveries & Insights`セクションに実装中の発見を記録
-- **Open Questions解消時**: 未解決の質問が解消されたら、該当項目を取り消し線（~テキスト~）でマークし、「✅ 解決済み (YYYY-MM-DD)」を追加、採用した選択肢と理由を記載
-- **新しい疑問発生時**: 実装中に新たな問題や疑問が発生したら、`Open Questions`に追加
-- **Follow-up事項発生時**: 今回のスコープでは対応しないが将来対応すべき事項は、`Follow-up Issues`に追加
-- **仕様の明確化時**: 実装中に仕様が明確化された場合は、`Specification / 仕様`セクションを更新
+- 主要な決定時 → `Decision Log`を更新
+- 機能実装完了時 → `Discoveries & Insights`に発見を記録
+- Open Questions解消時 → 取り消し線（~テキスト~）でマーク、「✅ 解決済み (YYYY-MM-DD)」を追加
+- 新しい疑問発生時 → `Open Questions`に追加
+- Follow-up事項発生時 → `Follow-up Issues`に追加
+- 仕様明確化時 → `Specification / 仕様`を更新
 
-**更新方法:**
-- EditツールまたはWriteツールを使用して進捗ドキュメントを更新
-- セクション単位での部分更新を推奨（ファイル全体の書き換えは避ける）
-- 更新後は`issync push`を実行してGitHub Issueに同期する
-
-**進捗ドキュメントはSingle Source of Truth**: GitHub Issueコメントと同期される進捗ドキュメントは、プロジェクトの現在の状態を表す唯一の真実の情報源です。継続的な更新により、他のセッションや将来の作業でコンテキストを正確に把握できます。
+**更新方法:** Editツールでセクション単位で更新し、`issync push`で同期。進捗ドキュメントはSingle Source of Truthであり、他のセッションや将来の作業でコンテキストを正確に把握するための唯一の情報源です。
 
 ### ステップ5: テストの実行
 
-実装が完了したら、以下のテストを実行してください：
-
-1. **単体テスト**: 追加・変更した機能のテストを実行
-   ```bash
-   bun test
-   ```
-
-2. **型チェック**: TypeScriptの型エラーがないか確認
-   ```bash
-   bun run type-check
-   ```
-
-3. **コード品質チェック**: Biome linterとformatterを実行
-   ```bash
-   bun run check
-   ```
-
-4. **統合チェック**: すべてのチェックを一括実行（pre-commit hookと同じ）
-   ```bash
-   bun run check:ci
-   ```
-
-テストが失敗した場合は、エラーを修正してから再度テストを実行してください。
+実装が完了したら、`bun run check:ci`ですべてのチェックを実行（単体テスト、型チェック、コード品質チェックを含む）。個別実行: `bun test`、`bun run type-check`、`bun run check`。テスト失敗時はエラーを修正して再実行。
 
 ### ステップ6: 進捗ドキュメントの最終同期
 
@@ -146,47 +112,35 @@ issync push
 
 ## 出力フォーマット
 
-実装完了後、以下のサマリーを出力してください：
+実装完了後、以下のサマリーを出力:
 
 ```markdown
 ## /implement 実行結果
 
 ✅ 実装が完了しました
-
-**Issue**: <issue_url>
-**ファイル**: <progress_document_path>
+**Issue**: <issue_url> | **ファイル**: <progress_document_path>
 
 ### 実装内容
-- [実装した機能1]
-- [実装した機能2]
-- [実装した機能3]
+- [実装した機能1-3]
 
 ### テスト結果
-- ✅ 単体テスト: 成功
-- ✅ 型チェック: 成功
-- ✅ コード品質チェック: 成功
+✅ 単体テスト | 型チェック | コード品質チェック
 
 ### 進捗ドキュメント更新
-- ✅ Decision Log: [X]件の決定を記録
-- ✅ Discoveries & Insights: [Y]件の発見を記録
-- ✅ Open Questions: [Z]件を解消
-- ✅ GitHub Issueへの同期: 完了（issync push）
+✅ Decision Log: [X]件 | Discoveries & Insights: [Y]件 | Open Questions: [Z]件解消 | GitHub Issueへの同期完了
 
 ### 次のアクション
 - [ ] PRの作成とレビュー依頼
-- [ ] 必要に応じてOpen Questionsの解消
 - [ ] 完了後は`/complete-sub-issue`で親issueに反映（サブissueの場合）
 ```
 
 ## 重要な注意事項
 
-1. **進捗ドキュメント駆動**: `Specification / 仕様`セクションに基づいて実装を進める
-2. **継続的更新**: 実装中は常に進捗ドキュメントを更新する（最重要）
-3. **Single Source of Truth**: 進捗ドキュメントはプロジェクトの唯一の真実の情報源
-4. **テスト駆動**: `Validation & Acceptance Criteria`に基づいてテストを追加・実行
-5. **issync連携**: 作業後は`issync push`でGitHub Issueに同期
-6. **エラーハンドリング**: テスト失敗時は修正してから再テスト
-7. **Status変更なし**: GitHub Projects Statusの変更は行わない（PRマージ時に自動変更される）
+1. **進捗ドキュメント駆動**: `Specification / 仕様`に基づいて実装
+2. **継続的更新**: 実装中は常に進捗ドキュメントを更新（最重要）
+3. **テスト駆動**: `Validation & Acceptance Criteria`に基づいてテスト追加・実行
+4. **issync連携**: 作業後は`issync push`で同期
+5. **Status変更なし**: GitHub Projects Statusの変更は行わない（PRマージ時に自動変更）
 
 ## 実行を開始
 


### PR DESCRIPTION
Add `/contradiction-tools:implement` command to automate the implementation phase:
- Created `.claude-plugins/contradiction-tools/commands/implement.md`
- Updated plugin README with command documentation
- Follows existing command patterns (`/understand-progress`)
- Accepts optional Issue URL or Issue number
- Emphasizes continuous progress document updates during implementation
- Designed for GitHub Actions (Claude Code Action) execution

Closes #46

Generated with [Claude Code](https://claude.ai/code)