### PR TITLE
feat: skip .gitignore recommendation if .issync already present

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,6 +55,7 @@ program
   )
   .action(async (issueUrl: string, options: { file?: string; template?: string }) => {
     const { init } = await import('./commands/init.js')
+    const { hasIssyncInGitignore } = await import('./lib/gitignore.js')
     const templateLine = options.template ? `\n  Template: ${options.template}` : ''
     let actualFilePath = ''
 
@@ -65,8 +66,13 @@ program
           template: options.template,
         })
       },
-      () =>
-        `✓ Initialized issync\n  Issue: ${issueUrl}\n  File:  ${actualFilePath}${templateLine}\n\nRecommended: Add .issync/ to your .gitignore`,
+      () => {
+        const baseMessage = `✓ Initialized issync\n  Issue: ${issueUrl}\n  File:  ${actualFilePath}${templateLine}`
+        const gitignoreRecommendation = hasIssyncInGitignore()
+          ? ''
+          : '\n\nRecommended: Add .issync/ to your .gitignore'
+        return baseMessage + gitignoreRecommendation
+      },
     )
   })
 

--- a/packages/cli/src/lib/gitignore.test.ts
+++ b/packages/cli/src/lib/gitignore.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { hasIssyncInGitignore } from './gitignore.js'
+
+describe('hasIssyncInGitignore', () => {
+  let testDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    // Save original working directory
+    originalCwd = process.cwd()
+
+    // Create test directory
+    testDir = join(process.cwd(), '.test-gitignore')
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true })
+    }
+    mkdirSync(testDir, { recursive: true })
+
+    // Change to test directory
+    process.chdir(testDir)
+  })
+
+  afterEach(() => {
+    // Restore original working directory
+    process.chdir(originalCwd)
+
+    // Clean up test directory
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true })
+    }
+  })
+
+  it('returns false when .gitignore does not exist', () => {
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+
+  it('returns false when .gitignore exists but is empty', () => {
+    writeFileSync('.gitignore', '')
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+
+  it('returns false when .gitignore exists but does not contain .issync', () => {
+    writeFileSync('.gitignore', 'node_modules/\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+
+  it('returns true when .gitignore contains .issync/', () => {
+    writeFileSync('.gitignore', 'node_modules/\n.issync/\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns true when .gitignore contains .issync without trailing slash', () => {
+    writeFileSync('.gitignore', 'node_modules/\n.issync\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns true when .gitignore contains /.issync/', () => {
+    writeFileSync('.gitignore', 'node_modules/\n/.issync/\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns true when .gitignore contains .issync/*', () => {
+    writeFileSync('.gitignore', 'node_modules/\n.issync/*\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns false when .issync is only in a comment', () => {
+    writeFileSync('.gitignore', 'node_modules/\n# .issync/\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+
+  it('returns true when .issync has inline comment', () => {
+    writeFileSync('.gitignore', 'node_modules/\n.issync/ # issync files\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns false when .gitignore contains only comments', () => {
+    writeFileSync('.gitignore', '# Comment 1\n# Comment 2\n')
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+
+  it('returns true when .issync is the first line', () => {
+    writeFileSync('.gitignore', '.issync/\nnode_modules/\ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns true when .issync is the last line', () => {
+    writeFileSync('.gitignore', 'node_modules/\ndist/\n.issync/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns false when .gitignore has only whitespace', () => {
+    writeFileSync('.gitignore', '   \n\t\n  \n')
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+
+  it('returns true when .issync has leading/trailing whitespace', () => {
+    writeFileSync('.gitignore', 'node_modules/\n  .issync/  \ndist/\n')
+    expect(hasIssyncInGitignore()).toBe(true)
+  })
+
+  it('returns false when file read fails (permission error simulation)', () => {
+    // Create a directory named .gitignore to cause read error
+    mkdirSync('.gitignore')
+    expect(hasIssyncInGitignore()).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/gitignore.ts
+++ b/packages/cli/src/lib/gitignore.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Check if .issync is present in the project root .gitignore file
+ * @returns true if .gitignore exists and contains .issync entry, false otherwise
+ */
+export function hasIssyncInGitignore(): boolean {
+  const gitignorePath = join(process.cwd(), '.gitignore')
+
+  // Return false if .gitignore doesn't exist
+  if (!existsSync(gitignorePath)) {
+    return false
+  }
+
+  try {
+    const content = readFileSync(gitignorePath, 'utf-8')
+    const lines = content.split('\n')
+
+    // Check each line for .issync entry
+    for (const line of lines) {
+      const trimmedLine = line.trim()
+
+      // Skip empty lines and comments
+      if (trimmedLine === '' || trimmedLine.startsWith('#')) {
+        continue
+      }
+
+      // Check if line contains .issync
+      if (trimmedLine.includes('.issync')) {
+        return true
+      }
+    }
+
+    return false
+  } catch {
+    // If file can't be read, return false
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Implements #40 to skip the `.gitignore` recommendation message in `issync init` when `.issync/` is already present in the project's `.gitignore` file.

## Changes

- Added `hasIssyncInGitignore()` utility function in `packages/cli/src/lib/gitignore.ts`
- Added 15 comprehensive unit tests for the utility function
- Updated `cli.ts` init command to conditionally show recommendation message

## Design Decisions

Follows the design decisions documented in the progress document:

1. **Pattern Matching**: Uses partial match with `.includes('.issync')` for flexibility
2. **Utility Function**: New `gitignore.ts` file with `hasIssyncInGitignore()` function
3. **Scope**: Checks project root `.gitignore` only (based on `process.cwd()`)

## Testing

✅ All 15 unit tests passing
✅ Follows existing code patterns

Closes #40

---

Generated with [Claude Code](https://claude.ai/code)