### PR TITLE
feat: replace CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS with GITHUB_PROJECTS_NUMBER

### DIFF
--- a/.claude-plugins/contradiction-tools/README.md
+++ b/.claude-plugins/contradiction-tools/README.md
@@ -28,13 +28,17 @@ GitHub Issue を単一の真実の情報源として、進捗ドキュメント�
 
 5. **GitHub Projects統合の設定**（オプション）:
 
-   GitHub Projectsを使用するプロジェクトでは、環境変数を設定してください：
+   GitHub Projectsを使用するプロジェクトでは、以下の環境変数を設定してください：
 
    ```bash
-   export CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS=true
+   export GITHUB_PROJECTS_NUMBER=1                    # プロジェクト番号（例: 1）
+   export GITHUB_PROJECTS_OWNER_TYPE=user             # プロジェクト所有者タイプ（user または org、デフォルト: user）
    ```
 
-   未設定の場合、GitHub Projects操作（Status/Stage変更）はスキップされます。
+   - `GITHUB_PROJECTS_NUMBER`: GitHub Projects の番号（プロジェクトURLの末尾の番号、例: `https://github.com/users/username/projects/1` → `1`）
+   - `GITHUB_PROJECTS_OWNER_TYPE`: プロジェクト所有者タイプ（`user` または `org`）。未設定の場合はデフォルトで `user` を使用します。
+
+   これらの環境変数が未設定の場合、GitHub Projects操作（Status/Stage変更）はスキップされます。
 
 ### インストール
 

--- a/.claude-plugins/contradiction-tools/commands/complete-sub-issue.md
+++ b/.claude-plugins/contradiction-tools/commands/complete-sub-issue.md
@@ -141,7 +141,9 @@ issync remove --issue <サブissue URL>
 
 ### ステップ9: GitHub Projects Status変更
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、サブissueのStatus→`done`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で更新。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、サブissueのStatus→`done`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で更新。
+
+プロジェクト所有者タイプは`!env GITHUB_PROJECTS_OWNER_TYPE`（デフォルト: `user`）を使用。
 
 ```bash
 gh api graphql -f query='...'  # Project情報取得

--- a/.claude-plugins/contradiction-tools/commands/plan.md
+++ b/.claude-plugins/contradiction-tools/commands/plan.md
@@ -44,7 +44,7 @@ description: planフェーズのプロセスを標準化し、コードベース
 
 **Stage設定（AI作業開始）**:
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
 
 ### ステップ2: GitHub Issue内容の確認
 
@@ -133,11 +133,13 @@ issync push
 
 **Stage更新（レビュー待ち）**:
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
 
 ### ステップ7: GitHub Projects Status & Stage自動変更
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、Status→`poc`、Stage→`To Start`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で両フィールドを更新。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、Status→`poc`、Stage→`To Start`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で両フィールドを更新。
+
+プロジェクト所有者タイプは`!env GITHUB_PROJECTS_OWNER_TYPE`（デフォルト: `user`）を使用。
 
 **エラー時**: 認証スコープ不足の場合は`gh auth refresh -s project`実行。失敗時はGitHub Projects UIで手動変更。
 

--- a/.claude-plugins/contradiction-tools/commands/review-poc.md
+++ b/.claude-plugins/contradiction-tools/commands/review-poc.md
@@ -44,7 +44,7 @@ description: POC実装の結果をレビューし、人間の意思決定のた�
 
 ### ステップ1: Stage設定（AI作業開始）
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
 
 ---
 
@@ -502,7 +502,7 @@ issync push
 
 ### ステップ11: Stage更新（レビュー待ち）
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
 
 **重要**: 人間承認後、Status→`implement`、Stage→`To Start`を手動で変更。
 


### PR DESCRIPTION
Replace boolean environment variable with project-specific configuration

## Changes
- Replace `CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS` with `GITHUB_PROJECTS_NUMBER` and `GITHUB_PROJECTS_OWNER_TYPE`
- Update all plugin command files and README

Resolves #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)) | [View job run](https://github.com/MH4GF/issync/actions/runs/19032767763) | [Branch](https://github.com/MH4GF/issync/tree/claude/issue-42-20251103-1118