### PR TITLE
feat: replace CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS with GITHUB_PROJECTS_NUMBER and GITHUB_PROJECTS_OWNER_TYPE

### DIFF
--- a/.claude-plugins/issync/README.md
+++ b/.claude-plugins/issync/README.md
@@ -10,7 +10,11 @@ GitHub Issue を単一の真実の情報源として、進捗ドキュメント�
 2. **GitHub CLI (`gh`)**: https://cli.github.com/
 3. **GITHUB_TOKEN**: `export GITHUB_TOKEN=$(gh auth token)` (GitHub Actionsでは自動設定)
 4. **issync watch**: `issync watch` (推奨)
-5. **GitHub Projects統合** (オプション): `export CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS=true`
+5. **GitHub Projects統合** (オプション):
+   ```bash
+   export GITHUB_PROJECTS_NUMBER=1  # プロジェクト番号
+   export GITHUB_PROJECTS_OWNER_TYPE=user  # 'user' または 'org' (デフォルト: user)
+   ```
 
 ### インストール
 

--- a/.claude-plugins/issync/commands/complete-sub-issue.md
+++ b/.claude-plugins/issync/commands/complete-sub-issue.md
@@ -141,14 +141,18 @@ issync remove --issue <サブissue URL>
 
 ### ステップ9: GitHub Projects Status変更
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、サブissueのStatus→`done`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で更新。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、サブissueのStatus→`done`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で更新。
+
+環境変数:
+- `GITHUB_PROJECTS_NUMBER`: プロジェクト番号（例: `1`）
+- `GITHUB_PROJECTS_OWNER_TYPE`: `user` または `org`（デフォルト: `user`）
 
 ```bash
 gh api graphql -f query='...'  # Project情報取得
 gh project item-edit --id <item-id> --project-id <project-id> --field-id <status-field-id> --option-id <done-option-id>
 ```
 
-**エラー時**: 認証エラーは`gh auth refresh -s project`、その他失敗時は警告のみで作業継続（手動変更案内）
+**エラー時**: 認証エラーは`gh auth refresh -s project`、その他失敗時は警告のみで作業継続（手動変更案内）。環境変数の形式が不正、プロジェクトが見つからない、権限不足の場合は警告を表示して処理を継続。
 
 ### ステップ10: GitHub Issueへの同期
 

--- a/.claude-plugins/issync/commands/plan.md
+++ b/.claude-plugins/issync/commands/plan.md
@@ -44,7 +44,11 @@ description: planフェーズのプロセスを標準化し、コードベース
 
 **Stage設定（AI作業開始）**:
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
+
+環境変数:
+- `GITHUB_PROJECTS_NUMBER`: プロジェクト番号（例: `1`）
+- `GITHUB_PROJECTS_OWNER_TYPE`: `user` または `org`（デフォルト: `user`）
 
 ### ステップ2: GitHub Issue内容の確認
 
@@ -133,13 +137,17 @@ issync push
 
 **Stage更新（レビュー待ち）**:
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
 
 ### ステップ7: GitHub Projects Status & Stage自動変更
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、Status→`poc`、Stage→`To Start`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で両フィールドを更新。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、Status→`poc`、Stage→`To Start`に変更。GraphQL APIでProject ID取得後、`gh project item-edit`で両フィールドを更新。
 
-**エラー時**: 認証スコープ不足の場合は`gh auth refresh -s project`実行。失敗時はGitHub Projects UIで手動変更。
+環境変数に基づいてプロジェクトを特定:
+- `GITHUB_PROJECTS_NUMBER`: プロジェクト番号（例: `1`）
+- `GITHUB_PROJECTS_OWNER_TYPE`: `user` または `org`（デフォルト: `user`）
+
+**エラー時**: 認証スコープ不足の場合は`gh auth refresh -s project`実行。失敗時はGitHub Projects UIで手動変更。環境変数の形式が不正、プロジェクトが見つからない、権限不足の場合は警告を表示して処理を継続。
 
 ## 出力フォーマット
 

--- a/.claude-plugins/issync/commands/review-poc.md
+++ b/.claude-plugins/issync/commands/review-poc.md
@@ -44,7 +44,11 @@ description: POC実装の結果をレビューし、人間の意思決定のた�
 
 ### ステップ1: Stage設定（AI作業開始）
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`In Progress`に設定。失敗時も作業継続（警告のみ）。
+
+環境変数:
+- `GITHUB_PROJECTS_NUMBER`: プロジェクト番号（例: `1`）
+- `GITHUB_PROJECTS_OWNER_TYPE`: `user` または `org`（デフォルト: `user`）
 
 ---
 
@@ -502,7 +506,7 @@ issync push
 
 ### ステップ11: Stage更新（レビュー待ち）
 
-`!env CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS`が`true`の場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
+`!env GITHUB_PROJECTS_NUMBER`が設定されている場合のみ、`gh project item-edit`でStage→`To Review`に設定。失敗時も作業継続（警告のみ）。
 
 **重要**: 人間承認後、Status→`implement`、Stage→`To Start`を手動で変更。
 


### PR DESCRIPTION
## Summary

This PR replaces the boolean environment variable `CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS` with two new variables: `GITHUB_PROJECTS_NUMBER` and `GITHUB_PROJECTS_OWNER_TYPE`. This enables explicit specification of which GitHub Project to operate on, rather than a simple enable/disable flag.

## Changes

- Replaced `CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS` with `GITHUB_PROJECTS_NUMBER` and `GITHUB_PROJECTS_OWNER_TYPE`
- Updated plugin command files: `plan.md`, `review-poc.md`, `complete-sub-issue.md`
- Updated README.md Quick Start section with new environment variable usage
- Added error handling for invalid environment variables (warning continuation)

## Environment Variable Usage

**Before:**
```bash
export CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS=true
```

**After:**
```bash
export GITHUB_PROJECTS_NUMBER=1  # Project number from GitHub UI
export GITHUB_PROJECTS_OWNER_TYPE=user  # 'user' or 'org' (default: user)
```

## Breaking Changes

⚠️ This is a breaking change. The old `CONTRADICTION_TOOLS_ENABLE_GITHUB_PROJECTS` environment variable is no longer supported. Users must update to the new environment variables.

## Testing

- Verified all old environment variable references removed
- Progress document updated with Specification and Outcomes

Resolves #42

🤖 Generated with [Claude Code](https://claude.ai/code)