### PR TITLE
Change default filename prefix from 'plan-' to 'progress-'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This is a bun workspaces monorepo with the following structure:
 - **Conflict Detection via Edit() Failures**: When issync pulls remote changes, Claude Code's Edit() tool naturally fails (old_string not found), triggering a re-read and retry.
 - **Optimistic Locking**: Hash-based conflict detection on the push side prevents overwriting remote changes.
 
-See the progress document (`docs/plan-*.md`) for detailed architecture decisions, progress tracking, and development phases.
+See the progress document (`docs/progress-*.md`) for detailed architecture decisions, progress tracking, and development phases.
 
 ## Development Commands
 
@@ -130,7 +130,7 @@ issync uses a global configuration file:
 syncs:
   - issue_url: https://github.com/owner/repo/issues/123
     comment_id: 123456789               # Set after first sync
-    local_file: /Users/user/project/.issync/docs/plan-123.md
+    local_file: /Users/user/project/.issync/docs/progress-123.md
     last_synced_hash: abc123def         # Remote content hash for optimistic locking
     last_synced_at: 2025-10-12T10:30:00Z
     poll_interval: 10                   # Seconds between remote polls (optional)
@@ -217,7 +217,7 @@ issync watch                          # Start watch FIRST
 
 ## Important Files
 
-- `docs/plan-*.md`: Progress documents - living development plans (progress, decisions, architecture)
+- `docs/progress-*.md`: Progress documents - living development plans (progress, decisions, architecture)
 - `src/types/index.ts`: Core data structures
 - `~/.issync/state.yml`: Global configuration (shared across all projects)
 
@@ -228,7 +228,7 @@ issync watch                          # Start watch FIRST
 issyncで管理されるドキュメントの総称。GitHub Issueコメントとローカルファイル間で双方向同期される、プロジェクトの進捗や意思決定を記録する生きたドキュメント。
 
 **特徴:**
-- ファイル名パターン: `plan-{番号}-{slug}.md` (例: `plan-123-watch-daemon.md`)
+- ファイル名パターン: `progress-{番号}-{slug}.md` (例: `progress-123-watch-daemon.md`)
 - テンプレート: `docs/progress-document-template.md`から生成
 - 用途: 開発進捗の記録、アーキテクチャ決定、タスク管理、振り返り
 - 同期先: GitHub Issueコメント（HTML comment markersで識別）
@@ -256,7 +256,7 @@ This project uses GitHub Actions to automate AI-driven development workflows.
 - **Usage**:
   - Create new Issue with `issync` label → auto-plan runs
   - Add `issync` label to existing Issue → auto-plan runs
-- **Output**: Creates `.issync/docs/plan-{number}-{slug}.md` and syncs to Issue comment
+- **Output**: Creates `.issync/docs/progress-{number}-{slug}.md` and syncs to Issue comment
 
 ### Setup Requirements
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -93,10 +93,10 @@ describe('init command', () => {
     expect(state.syncs).toHaveLength(1)
     const config = state.syncs[0]
 
-    expect(config?.local_file).toBe(path.join(TEST_DIR, '.issync/docs/plan-123.md'))
+    expect(config?.local_file).toBe(path.join(TEST_DIR, '.issync/docs/progress-123.md'))
 
     // Verify file was actually created at the expected path
-    const expectedFilePath = path.join(TEST_DIR, '.issync/docs/plan-123.md')
+    const expectedFilePath = path.join(TEST_DIR, '.issync/docs/progress-123.md')
     expect(existsSync(expectedFilePath)).toBe(true)
   })
 
@@ -123,12 +123,12 @@ describe('init command', () => {
 
     const state = loadConfig(TEST_DIR)
     expect(state.syncs).toHaveLength(2)
-    expect(state.syncs[0]?.local_file).toBe(path.join(TEST_DIR, '.issync/docs/plan-1.md'))
-    expect(state.syncs[1]?.local_file).toBe(path.join(TEST_DIR, '.issync/docs/plan-999.md'))
+    expect(state.syncs[0]?.local_file).toBe(path.join(TEST_DIR, '.issync/docs/progress-1.md'))
+    expect(state.syncs[1]?.local_file).toBe(path.join(TEST_DIR, '.issync/docs/progress-999.md'))
 
     // Verify both files were created
-    expect(existsSync(path.join(TEST_DIR, '.issync/docs/plan-1.md'))).toBe(true)
-    expect(existsSync(path.join(TEST_DIR, '.issync/docs/plan-999.md'))).toBe(true)
+    expect(existsSync(path.join(TEST_DIR, '.issync/docs/progress-1.md'))).toBe(true)
+    expect(existsSync(path.join(TEST_DIR, '.issync/docs/progress-999.md'))).toBe(true)
   })
 
   test('dynamic default path works with template option', async () => {
@@ -142,7 +142,7 @@ describe('init command', () => {
 
     const state = loadConfig(TEST_DIR)
     const targetFile = state.syncs[0]?.local_file
-    expect(targetFile).toBe(path.join(TEST_DIR, '.issync/docs/plan-456.md'))
+    expect(targetFile).toBe(path.join(TEST_DIR, '.issync/docs/progress-456.md'))
 
     // Verify template content was used
     if (!targetFile) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -222,7 +222,7 @@ export async function init(issueUrl: string, options: InitOptions = {}): Promise
   const issueInfo = parseIssueUrl(issueUrl)
 
   // Use dynamic default based on issue number if no file is provided
-  let targetFile = file ?? `.issync/docs/plan-${issueInfo.issue_number}.md`
+  let targetFile = file ?? `.issync/docs/progress-${issueInfo.issue_number}.md`
 
   // Convert to absolute path
   targetFile = toAbsolutePath(targetFile, workingDir)


### PR DESCRIPTION
## Summary

This PR changes the default filename prefix in `issync init` from `plan-` to `progress-`, unifying naming conventions across the codebase to match the progress-document-template.md and project terminology.

## Changes

- Updated `init.ts` default filename to use `progress-` prefix
- Updated test cases to reflect new default filename pattern
- Updated CLAUDE.md documentation (5 occurrences)

## Backward Compatibility

Existing `plan-*.md` files remain unaffected. Only new `issync init` invocations will use the new `progress-` prefix.

Closes #68

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/MH4GF/issync/actions/runs/19122667728) | [View branch](https://github.com/MH4GF/issync/tree/claude/issue-68-20251106-0219