### PR TITLE
docs: abstract internal implementation paths from user documentation

### DIFF
--- a/.claude-plugins/issync/commands/create-sub-issue.md
+++ b/.claude-plugins/issync/commands/create-sub-issue.md
@@ -6,7 +6,7 @@ description: 新規タスクをGitHub Issueとして作成し、親issueとの�
 
 新規タスクをGitHub Issueとして作成し、以下を自動化：
 1. タスク概要決定（会話コンテキストから自動抽出 / 引数指定 / 対話入力）
-2. 親issue情報取得（`.issync/state.yml`）
+2. 親issue情報取得（設定ファイル）
 3. LLMによるタイトル・本文生成
 4. Issue作成（`ISSYNC_LABELS_AUTOMATION=true`の場合、`issync:plan`ラベル自動付与）
 5. Sub-issues API連携（親issue紐づけ + 順序維持）
@@ -34,7 +34,7 @@ description: 新規タスクをGitHub Issueとして作成し、親issueとの�
 
 ## 前提条件
 
-- `.issync/state.yml`存在（`issync init`完了済み）
+- issync設定が存在（`issync init`完了済み）
 - `ISSYNC_GITHUB_TOKEN`環境変数設定
 - `gh` CLIインストール済み
 - `ISSYNC_LABELS_AUTOMATION=true`設定時: リポジトリに`issync:plan`ラベルが存在すること
@@ -187,7 +187,7 @@ done
 
 **必須要件**:
 - ステップ1で環境変数を確認し、モードフラグを設定（以降のステップで参照）
-- 親issueの進捗ドキュメント全体読み込み（`.issync/state.yml`のlocal_fileパス使用）
+- 親issueの進捗ドキュメント全体読み込み（設定ファイルのlocal_fileパス使用）
 - タイトル・本文はLLM生成、ユーザー確認必須
 - gh CLI使用、内部ID使用（`gh api .../issues/{番号} --jq .id`）
 - `ISSYNC_LABELS_AUTOMATION=true`の場合、`issync:plan`ラベル自動付与

--- a/.claude-plugins/issync/commands/review-poc.md
+++ b/.claude-plugins/issync/commands/review-poc.md
@@ -472,7 +472,7 @@ graph TD
 - Grace period: pullから10秒間はpushを抑制（ループ防止）
 
 **実装方針**:
-- Daemon processとして実行、PIDを.issync/state.ymlに記録
+- Daemon processとして実行、PIDを設定ファイルに記録
 - Graceful shutdown（SIGTERM/SIGINT）に対応
 - エラーリトライ: 3回まで、指数バックオフ（POCでは未実装、本実装で追加）
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ issync init https://github.com/owner/repo/issues/123 --file docs/plan.md
 **Behavior:**
 - Detects existing issync-managed comments on the Issue and pulls the content
 - Creates a new file from template if no existing comment is found
-- Config is stored in `~/.issync/state.yml` (global configuration)
+- Config is stored in your home directory (global configuration)
 
 ### `issync pull`
 
@@ -218,7 +218,7 @@ issync remove --file docs/plan.md --delete-file
 
 ### Config File Location
 
-issync stores its configuration in `~/.issync/state.yml` (global configuration in your home directory). This allows tracking issues across multiple repositories from a single location.
+issync stores its configuration in your home directory (global configuration). This allows tracking issues across multiple repositories from a single location.
 
 ### Config File Format
 
@@ -247,7 +247,7 @@ Add `.issync/` to your project's `.gitignore` to exclude progress documents:
 
 **Note**:
 - Progress documents (`.issync/docs/`) are synced via GitHub Issues and should not be tracked by git
-- The global config file (`~/.issync/state.yml`) is in your home directory and doesn't need to be git-ignored
+- The configuration file is in your home directory and doesn't need to be git-ignored
 
 ## Workflow for AI Agents
 

--- a/packages/cli/src/lib/config.test.ts
+++ b/packages/cli/src/lib/config.test.ts
@@ -281,7 +281,7 @@ describe('config', () => {
   describe('loadConfig', () => {
     test('throws ConfigNotFoundError when state file does not exist', () => {
       // Act & Assert: Should throw custom error
-      expect(() => loadConfig(testDir)).toThrow('.issync/state.yml not found')
+      expect(() => loadConfig(testDir)).toThrow('Configuration not found')
     })
 
     test('loads config from state file', () => {

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -7,7 +7,7 @@ class IssyncError extends Error {
 
 export class ConfigNotFoundError extends IssyncError {
   constructor() {
-    super('.issync/state.yml not found. Run `issync init` first.')
+    super('Configuration not found. Run `issync init` first.')
     this.name = 'ConfigNotFoundError'
   }
 }


### PR DESCRIPTION
Abstract references to `~/.issync/state.yml` and `.issync/state.yml` from user-facing documentation and error messages, improving UX by hiding implementation details that users don't need to know.

## Changes
- README.md: Replace 3 path references with "in your home directory"
- errors.ts: Update ConfigNotFoundError message
- create-sub-issue.md: Replace 3 path references with "設定ファイル"
- review-poc.md: Replace 1 path reference with "設定ファイル"
- config.test.ts: Update test expectation for new error message

Part of #28
Closes https://github.com/MH4GF/issync/issues/89


🤖 Generated with [Claude Code](https://claude.ai/code)